### PR TITLE
Bump alpine from 3.18.3 to 3.18.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the game in a base container
-FROM alpine:3.18.3 AS builder
+FROM alpine:3.18.4 AS builder
 LABEL "Maintainer" "Florian Piesche <florian@yellowkeycard.net>"
 
 ENV SERVERBIN ioq3ded
@@ -13,7 +13,7 @@ RUN \
   make copyfiles
 
 # Copy the game files from the builder container to a new image to minimise size
-FROM alpine:3.18.3 AS ioq3srv
+FROM alpine:3.18.4 AS ioq3srv
 ARG IOQUAKE3_COMMIT="unknown"
 LABEL "Maintainer" "Florian Piesche <florian@yellowkeycard.net>"
 


### PR DESCRIPTION
Bumps alpine from 3.18.3 to 3.18.4.

---
updated-dependencies:
- dependency-name: alpine dependency-type: direct:production update-type: version-update:semver-patch ...